### PR TITLE
fix provider workflow to work without container specific names

### DIFF
--- a/.github/workflows/provider.yaml
+++ b/.github/workflows/provider.yaml
@@ -58,14 +58,10 @@ jobs:
 
       - name: Run lakeFS DAG
         run: |
-          docker-compose exec -T scheduler airflow connections add conn_1 --conn-type=HTTP --conn-host=http://172.17.0.1:8000 --conn-extra='{"access_key_id":"${{ env.KEY }}","secret_access_key":"${{ env.SECRET }}"}'
-          docker-compose exec -T scheduler airflow dags unpause lakeFS_workflow
-          docker-compose exec -T scheduler airflow dags trigger lakeFS_workflow
+          astro dev run connections add conn_1 --conn-type=HTTP --conn-host=http://172.17.0.1:8000 --conn-extra='{"access_key_id":"${{ env.KEY }}","secret_access_key":"${{ env.SECRET }}"}'
+          astro dev run dags unpause lakeFS_workflow
+          astro dev run dags trigger lakeFS_workflow
           sleep 30
-
-      - name: scheduler logs on failure
-        if: ${{ failure() }}
-        run: docker-compose logs --tail=1000 scheduler
 
       - name: Upload file to sense
         env:
@@ -89,4 +85,4 @@ jobs:
 
       - name: airflow logs
         if: ${{ always() }}
-        run: docker-compose exec -T scheduler find /usr/local/airflow/logs/lakeFS_workflow/ -type f -exec cat {} \;
+        run: astro dev logs --scheduler

--- a/.github/workflows/provider.yaml
+++ b/.github/workflows/provider.yaml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Install astro
         env:
-          TAG: 0.25.0
+          TAG: 0.28.1
         run: curl -sSL https://install.astronomer.io | sudo bash -s
 
       - name: Create astro dev env

--- a/.github/workflows/provider.yaml
+++ b/.github/workflows/provider.yaml
@@ -59,11 +59,8 @@ jobs:
       - name: Run lakeFS DAG
         run: |
           cd astro
-          echo "add conn_1"
           astro dev run connections add conn_1 --conn-type=HTTP --conn-host=http://172.17.0.1:8000 --conn-extra='{"access_key_id":"${{ env.KEY }}","secret_access_key":"${{ env.SECRET }}"}'
-          echo "dag unpause"
           astro dev run dags unpause lakeFS_workflow
-          echo "dag trigger"
           astro dev run dags trigger lakeFS_workflow
           sleep 30
 

--- a/.github/workflows/provider.yaml
+++ b/.github/workflows/provider.yaml
@@ -60,7 +60,7 @@ jobs:
         run: |
           cd astro
           echo "add conn_1"
-          astro dev run connections add conn_1 --conn-type=http --conn-schema=http --conn-host=172.17.0.1 --conn-port=8000 --conn-extra='{"access_key_id":"${{ env.KEY }}","secret_access_key":"${{ env.SECRET }}"}'
+          astro dev run connections add conn_1 --conn-type=HTTP --conn-host=http://172.17.0.1:8000 --conn-extra='{"access_key_id":"${{ env.KEY }}","secret_access_key":"${{ env.SECRET }}"}'
           echo "dag unpause"
           astro dev run dags unpause lakeFS_workflow
           echo "dag trigger"

--- a/.github/workflows/provider.yaml
+++ b/.github/workflows/provider.yaml
@@ -63,6 +63,10 @@ jobs:
           docker-compose exec -T scheduler airflow dags trigger lakeFS_workflow
           sleep 30
 
+      - name: scheduler logs
+        if: ${{ failure() }}
+        run: docker-compose logs --tail=1000 scheduler
+
       - name: Upload file to sense
         env:
           # To avoid the lack of region - see https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html

--- a/.github/workflows/provider.yaml
+++ b/.github/workflows/provider.yaml
@@ -63,7 +63,7 @@ jobs:
           docker-compose exec -T scheduler airflow dags trigger lakeFS_workflow
           sleep 30
 
-      - name: scheduler logs
+      - name: scheduler logs on failure
         if: ${{ failure() }}
         run: docker-compose logs --tail=1000 scheduler
 

--- a/.github/workflows/provider.yaml
+++ b/.github/workflows/provider.yaml
@@ -58,9 +58,10 @@ jobs:
 
       - name: Run lakeFS DAG
         run: |
-          docker container exec astrobfff1f_scheduler_1 airflow connections add conn_1 --conn-type=HTTP --conn-host=http://172.17.0.1:8000 --conn-extra='{"access_key_id":"${{ env.KEY }}","secret_access_key":"${{ env.SECRET }}"}'
-          docker container exec astrobfff1f_scheduler_1 airflow dags unpause lakeFS_workflow
-          docker container exec astrobfff1f_scheduler_1 airflow dags trigger lakeFS_workflow && sleep 30
+          docker-compose exec -T scheduler airflow connections add conn_1 --conn-type=HTTP --conn-host=http://172.17.0.1:8000 --conn-extra='{"access_key_id":"${{ env.KEY }}","secret_access_key":"${{ env.SECRET }}"}'
+          docker-compose exec -T scheduler airflow dags unpause lakeFS_workflow
+          docker-compose exec -T scheduler airflow dags trigger lakeFS_workflow
+          sleep 30
 
       - name: Upload file to sense
         env:
@@ -84,4 +85,4 @@ jobs:
 
       - name: airflow logs
         if: ${{ always() }}
-        run: docker container exec astrobfff1f_scheduler_1 find /usr/local/airflow/logs/lakeFS_workflow/ -type f -exec cat {} \;
+        run: docker-compose exec -T scheduler find /usr/local/airflow/logs/lakeFS_workflow/ -type f -exec cat {} \;

--- a/.github/workflows/provider.yaml
+++ b/.github/workflows/provider.yaml
@@ -58,6 +58,7 @@ jobs:
 
       - name: Run lakeFS DAG
         run: |
+          cd astro
           astro dev run connections add conn_1 --conn-type=HTTP --conn-host=http://172.17.0.1:8000 --conn-extra='{"access_key_id":"${{ env.KEY }}","secret_access_key":"${{ env.SECRET }}"}'
           astro dev run dags unpause lakeFS_workflow
           astro dev run dags trigger lakeFS_workflow
@@ -85,4 +86,6 @@ jobs:
 
       - name: airflow logs
         if: ${{ always() }}
-        run: astro dev logs --scheduler
+        run: |
+          cd astro
+          astro dev logs --scheduler

--- a/.github/workflows/provider.yaml
+++ b/.github/workflows/provider.yaml
@@ -59,8 +59,11 @@ jobs:
       - name: Run lakeFS DAG
         run: |
           cd astro
-          astro dev run connections add conn_1 --conn-type=HTTP --conn-host=http://172.17.0.1:8000 --conn-extra='{"access_key_id":"${{ env.KEY }}","secret_access_key":"${{ env.SECRET }}"}'
+          echo "add conn_1"
+          astro dev run connections add conn_1 --conn-type=http --conn-schema=http --conn-host=172.17.0.1 --conn-port=8000 --conn-extra='{"access_key_id":"${{ env.KEY }}","secret_access_key":"${{ env.SECRET }}"}'
+          echo "dag unpause"
           astro dev run dags unpause lakeFS_workflow
+          echo "dag trigger"
           astro dev run dags trigger lakeFS_workflow
           sleep 30
 


### PR DESCRIPTION
Updated workflow:
- use latest astro
- astro cli to run airflow commands
- astro cli to extract airflow scheduler logs

Note that it looks like we need to update our implementation while using new connections, the schema and port have different settings - not part of host.