### PR TITLE
Add object upload operator

### DIFF
--- a/.github/workflows/provider.yaml
+++ b/.github/workflows/provider.yaml
@@ -59,7 +59,7 @@ jobs:
       - name: Run lakeFS DAG
         run: |
           cd astro
-          astro dev run connections add conn_1 --conn-type=HTTP --conn-host=http://172.17.0.1:8000 --conn-extra='{"access_key_id":"${{ env.KEY }}","secret_access_key":"${{ env.SECRET }}"}'
+          astro dev run connections add conn_lakefs --conn-type=HTTP --conn-host=http://172.17.0.1:8000 --conn-extra='{"access_key_id":"${{ env.KEY }}","secret_access_key":"${{ env.SECRET }}"}'
           astro dev run dags unpause lakeFS_workflow
           astro dev run dags trigger lakeFS_workflow
           sleep 30

--- a/.github/workflows/provider.yaml
+++ b/.github/workflows/provider.yaml
@@ -64,13 +64,7 @@ jobs:
           astro dev run dags trigger lakeFS_workflow
           sleep 30
 
-      - name: Upload file to sense
-        env:
-          # To avoid the lack of region - see https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html
-          AWS_EC2_METADATA_DISABLED: true
-        run: echo "hello world" | AWS_ACCESS_KEY_ID=${{ env.KEY }} AWS_SECRET_ACCESS_KEY=${{ env.SECRET }} aws s3 cp --endpoint-url=http://s3.local.lakefs.io:8000 - s3://example-repo/example-branch/file/to/sense/_SUCCESS
-
-      - name: Wait until file is available on main
+      - name: Wait until Airflow makes output file available on main
         env:
           # To avoid the lack of region - see https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html
           AWS_EC2_METADATA_DISABLED: true
@@ -78,7 +72,7 @@ jobs:
         with:
           timeout_minutes: 3
           max_attempts: 30
-          command: AWS_ACCESS_KEY_ID=${{ env.KEY }} AWS_SECRET_ACCESS_KEY=${{ env.SECRET }} aws s3 cp --endpoint-url=http://s3.local.lakefs.io:8000 s3://example-repo/main/file/to/sense/_SUCCESS -
+          command: AWS_ACCESS_KEY_ID=${{ env.KEY }} AWS_SECRET_ACCESS_KEY=${{ env.SECRET }} aws s3 cp --endpoint-url=http://s3.local.lakefs.io:8000 s3://example-repo/main/path/to/_SUCCESS -
 
       - name: lakeFS logs
         if: ${{ always() }}

--- a/lakefs_provider/hooks/lakefs_hook.py
+++ b/lakefs_provider/hooks/lakefs_hook.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Dict, Any, IO
 
 import lakefs_client
 from lakefs_client import models
@@ -57,6 +57,16 @@ class LakeFSHook(BaseHook):
 
         return commit.get("id")
 
+    def upload(self, repo: str, branch: str, path: str, content: IO) -> str:
+        client = self.get_conn()
+        upload = client.objects.upload_object(
+            repository=repo,
+            branch=branch,
+            path=path,
+            content=content)
+
+        return upload
+
     def merge(self, repo: str, source_ref: str, destination_branch: str,
               msg: str, metadata: Dict[str, Any] = None) -> str:
         client = self.get_conn()
@@ -76,5 +86,3 @@ class LakeFSHook(BaseHook):
     def stat_object(self, repo: str, ref: str, path: str) -> ObjectStats:
         client = self.get_conn()
         return client.objects.stat_object(repository=repo, ref=ref, path=path)
-
-

--- a/lakefs_provider/operators/upload_operator.py
+++ b/lakefs_provider/operators/upload_operator.py
@@ -1,0 +1,52 @@
+from typing import Any, Dict, IO
+
+from airflow.models import BaseOperator
+from airflow.utils.decorators import apply_defaults
+
+from lakefs_provider.hooks.lakefs_hook import LakeFSHook
+
+
+class LakeFSUploadOperator(BaseOperator):
+    """
+    Upload an object to a lakeFS repo.
+
+    :param lakefs_conn_id: connection to run the operator with
+    :type lakefs_conn_id: str
+    :param repo: The lakeFS repo for the desired object.
+    :type repo: str
+    :param branch: The branch name for the desired object.
+    :type branch: str
+    :param path: The path for the desired object.
+    :type msg: str
+    :param content: Contents of the desired object.
+    :type content: typing.IO
+    """
+
+    # Specify the arguments that are allowed to parse with jinja templating
+    template_fields = [
+        'repo',
+        'branch',
+        'path',
+    ]
+    template_ext = ()
+    ui_color = '#f4a460'
+
+    @apply_defaults
+    def __init__(self, lakefs_conn_id: str, repo: str, branch: str, path: str, content: IO = None, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.lakefs_conn_id = lakefs_conn_id
+        self.repo = repo
+        self.branch = branch
+        self.path = path
+        self.content = content
+        self.task_id = kwargs.get("task_id")
+
+    def execute(self, context: Dict[str, Any]) -> Any:
+        hook = LakeFSHook(lakefs_conn_id=self.lakefs_conn_id)
+
+        self.log.info("Uploading to path '%s' on lakeFS branch '%s' in repo '%s'",
+                      self.path, self.branch, self.repo)
+
+        stats = hook.upload(self.repo, self.branch, self.path, self.content)
+
+        return stats.physical_address

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-lakefs_client~=0.41.0
+lakefs_client~=0.66.0
 setuptools~=56.0.0


### PR DESCRIPTION
Tested manually on a standalone Airflow, after removing the commit_sensor step (which is not relevant to file uploads, but OTOH doesn't work with `airflow standalone` because of the required parallelism...).