### PR TITLE
Fix spelling of LakeFSHook in provider info

### DIFF
--- a/lakefs_provider/__init__.py
+++ b/lakefs_provider/__init__.py
@@ -4,7 +4,7 @@ def get_provider_info():
         "package-name": "airflow-provider-lakefs",
         "name": "lakeFS Airflow Provider",
         "description": "An Airflow provider of lakeFS",
-        "hook-class-names": ["lakefs_provider.hooks.lakefs_hook.LakefsHook"],
+        "hook-class-names": ["lakefs_provider.hooks.lakefs_hook.LakeFSHook"],
         "extra-links": ["lakefs_provider.operators.create_branch_operator.ExtraLink"],
         "versions": ["0.0.1"]
     }


### PR DESCRIPTION
Should remove this importerror:

```
ImportError: Module "lakefs_provider.hooks.lakefs_hook" does not define a "LakefsHook" attribute/class
```