### PR TITLE
Bump version to publish

### DIFF
--- a/.github/workflows/provider.yaml
+++ b/.github/workflows/provider.yaml
@@ -38,7 +38,7 @@ jobs:
           cp ./lakefs_provider/example_dags/lakefs-dag.py astro/dags/
 
       - name: Insert Dockerfile pip install
-        run: printf "\nRUN pip install --user dist/airflow_provider_lakefs-0.41.0.4-py3-none-any.whl" >> astro/Dockerfile
+        run: printf "\nRUN pip install --user dist/airflow_provider_lakefs-0.42.0-py3-none-any.whl" >> astro/Dockerfile
 
       - name: Start astro
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# 0.42.0
+
+* Added operators:
+  - LakeFSGetCommitOperator
+  - LakeFSUploadOperator
+
+* Changed operators:
+  - LakeFSCommitSensor now supports optional `prev_commit_id` argument.

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.md", "r") as fh:
 """Perform the package airflow-provider-lakeFS setup."""
 setup(
     name='airflow-provider-lakefs',
-    version="0.41.0.4",
+    version='0.42.0',
     description='A lakeFS provider package built by Treeverse.',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
New:

* Added operators:
  - LakeFSGetCommitOperator
  - LakeFSUploadOperator

* Changed operators:
  - LakeFSCommitSensor now supports optional `prev_commit_id` argument.