### PR TITLE
Use lakeFS client v0.91.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-lakefs_client~=0.66.0
+lakefs_client~=0.91.0
 setuptools~=56.0.0

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     packages=['lakefs_provider', 'lakefs_provider.hooks',
               'lakefs_provider.sensors', 'lakefs_provider.operators',
               'lakefs_provider.example_dags'],
-    install_requires=['apache-airflow>=2.0', 'lakefs_client>=0.41.0.1'],
+    install_requires=['apache-airflow>=2.0', 'lakefs_client>=0.91.0'],
     setup_requires=['setuptools', 'wheel'],
     author='Treeverse',
     author_email='services@treeverse.io',


### PR DESCRIPTION
In order to use latest lakeFS API - upgrade client to lakeFS v0.91.0.
It will prevent from breaking the airflow integration in the case lakeFS's merge API change in response. 
