### PR TITLE
Add DAG run metadata to commits

### DIFF
--- a/lakefs_provider/example_dags/lakefs-dag.py
+++ b/lakefs_provider/example_dags/lakefs-dag.py
@@ -1,8 +1,9 @@
 from typing import Dict
-from collections.abc import Sequence
+from typing import Sequence
 
 from collections import namedtuple
 from itertools import zip_longest
+import time
 
 from io import StringIO
 
@@ -35,7 +36,7 @@ default_args = {
 }
 
 
-CONTENT = 'It is not enough to succeed.  Others must fail.'
+CONTENT = 'It is not enough to succeed.  Others must fail.\n' + time.asctime()
 COMMIT_MESSAGE_1 = 'committing to lakeFS using airflow!'
 MERGE_MESSAGE_1 = 'merging to the default branch'
 

--- a/lakefs_provider/example_dags/lakefs-dag.py
+++ b/lakefs_provider/example_dags/lakefs-dag.py
@@ -36,7 +36,7 @@ default_args = {
 }
 
 
-CONTENT = 'It is not enough to succeed.  Others must fail.\n' + time.asctime()
+CONTENT_PREFIX = 'It is not enough to succeed.  Others must fail.'
 COMMIT_MESSAGE_1 = 'committing to lakeFS using airflow!'
 MERGE_MESSAGE_1 = 'merging to the default branch'
 
@@ -44,9 +44,9 @@ MERGE_MESSAGE_1 = 'merging to the default branch'
 IdAndMessage = namedtuple('IdAndMessage', ['id', 'message'])
 
 
-def check_equality(task_instance, actual: str, expected: str) -> None:
-    if actual != expected:
-        raise AirflowFailException(f'Got {actual} instead of {expected}')
+def check_expected_prefix(task_instance, actual: str, expected: str) -> None:
+    if not actual.startswith(expected):
+        raise AirflowFailException(f'Got:\n"{actual}"\nwhich does not start with\n{expected}')
 
 
 def check_logs(task_instance, repo: str, ref: str, commits: Sequence[str], messages: Sequence[str], amount: int=100) -> None:
@@ -96,7 +96,7 @@ def lakeFS_workflow():
     # Create a path.
     task_create_file = LakeFSUploadOperator(
         task_id='upload_file',
-        content=NamedStringIO(content=CONTENT, name='content'))
+        content=NamedStringIO(content=f"{CONTENT_PREFIX} @time.asctime()", name='content'))
 
     task_get_branch_commit = LakeFSGetCommitOperator(
         do_xcom_push=True,
@@ -142,11 +142,11 @@ def lakeFS_workflow():
 
     # Check its contents
     task_check_contents = PythonOperator(
-        task_id='check_equality',
-        python_callable=check_equality,
+        task_id='check_expected_prefix',
+        python_callable=check_expected_prefix,
         op_kwargs={
             'actual': '''{{ task_instance.xcom_pull(task_ids='get_object', key='return_value') }}''',
-            'expected': CONTENT,
+            'expected': CONTENT_PREFIX,
         })
 
     # Merge the changes back to the main branch.

--- a/lakefs_provider/operators/commit_operator.py
+++ b/lakefs_provider/operators/commit_operator.py
@@ -2,6 +2,10 @@ from typing import Any, Dict
 
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
+from airflow.utils.helpers import build_airflow_url_with_query
+from airflow.configuration import conf as airflow_conf
+
+from sqlalchemy.exc import SQLAlchemyError
 
 from lakefs_provider.hooks.lakefs_hook import LakeFSHook
 
@@ -32,6 +36,45 @@ class LakeFSCommitOperator(BaseOperator):
     template_ext = ()
     ui_color = '#f4a460'
 
+    metadata_prefix = "::lakefs::"
+
+    # DAG metadata to add to commit, expanded after fetching appropriate
+    # metadata.  The key of each metadata item will be prefixed
+    # "::lakefs::".
+    metadata_templates = {
+        "dag_run_id": "{{dag_run.run_id}}",
+        "dag_id": "{{dag.dag_id}}",
+        "logical_date": "{{logical_date}}",
+        "data_interval_start[iso8601]": "{{data_interval_start}}",
+        "data_interval_end[iso8601]": "{{data_interval_end}}",
+        "last_scheduling_decision": "{{dag_run.last_scheduling_decision}}",
+        "run_type": "{{dag_run.run_type}}",
+        "external_trigger": "{{dag_run.external_trigger}}",
+        "conf": "{{params}}",
+        "note": "{{dag_run.note}}",
+        # build_airflow_url_with_query can only run from a Flask app
+        # context.  Fake URLs instead.
+        "url[url:id]": '{{endpoint_url}}/api/v1/dags/{{dag.dag_id}}/dagRuns/{{dag_run.run_id}}',
+        "url[url:ui]": '{{endpoint_url}}/dags/{{dag.dag_id}}/graph?dag_run_id={{dag_run.run_id}}&root=&logical_date={{logical_date}}',
+    }
+    required_keys = ['dag', 'dag_run', 'logical_date', 'data_interval_start', 'data_interval_end', 'params']
+
+    def _get_current_dag_dict(self, context: Dict[str, Any]) -> Dict[str, Any]:
+        """Return a dict that describes parameters for the DAG run in context.
+
+        Dict has keys 'endpoint_url', 'id', 'run_id', 'logical_date'.
+        """
+        ret = {}
+        ret['endpoint_url'] = airflow_conf.get("webserver", "base_url")
+
+        for key in self.required_keys:
+            value = context.get(key, None)
+            if value is None:
+                self.log.warning(f"context does not contain {key}")
+            ret[key] = value
+
+        return ret
+
     @apply_defaults
     def __init__(self, lakefs_conn_id: str, repo: str, branch: str, msg: str, metadata: Dict[str, str] = None, **kwargs: Any) -> None:
         super().__init__(**kwargs)
@@ -49,6 +92,26 @@ class LakeFSCommitOperator(BaseOperator):
                       self.branch, self.repo)
 
         self.metadata.__setitem__("airflow_task_id", self.task_id)
+
+        # TODO(ariels): Configurably filter metadata keys.
+
+        cdd = self._get_current_dag_dict(context)
+        self.log.info("[DEBUG] cdd", cdd)
+
+        for k, template in self.metadata_templates.items():
+            try:
+                expanded = str(self.render_template(template, cdd))
+                self.metadata.__setitem__(self.metadata_key(k), expanded)
+            except SQLAlchemyError as sql_e:
+                self.log.warning(f"metadata {k} not added: ${sql_e} (possibly undefined fields)")
+
+
         ref = hook.commit(self.repo, self.branch, self.msg, self.metadata)
 
+        # TODO(ariels): Add lakeFS commit URL and commit UI URLs as links!
+
         return ref
+
+    @classmethod
+    def metadata_key(cls, key: str) -> str:
+        return cls.metadata_prefix + key

--- a/lakefs_provider/operators/commit_operator.py
+++ b/lakefs_provider/operators/commit_operator.py
@@ -96,7 +96,6 @@ class LakeFSCommitOperator(BaseOperator):
         # TODO(ariels): Configurably filter metadata keys.
 
         cdd = self._get_current_dag_dict(context)
-        self.log.info("[DEBUG] cdd", cdd)
 
         for k, template in self.metadata_templates.items():
             try:
@@ -107,8 +106,6 @@ class LakeFSCommitOperator(BaseOperator):
 
 
         ref = hook.commit(self.repo, self.branch, self.msg, self.metadata)
-
-        # TODO(ariels): Add lakeFS commit URL and commit UI URLs as links!
 
         return ref
 

--- a/lakefs_provider/operators/commit_operator.py
+++ b/lakefs_provider/operators/commit_operator.py
@@ -36,7 +36,7 @@ class LakeFSCommitOperator(BaseOperator):
     template_ext = ()
     ui_color = '#f4a460'
 
-    metadata_prefix = "::lakefs::"
+    metadata_prefix = "::lakefs::Airflow::"
 
     # DAG metadata to add to commit, expanded after fetching appropriate
     # metadata.  The key of each metadata item will be prefixed


### PR DESCRIPTION
Tested by running the sample DAG and seeing desired metadata on web.

Everything in [the design](https://github.com/treeverse/lakeFS/blob/master/design/open/commit-metadata/airflow.md#naming) except note is in there: UI link goes to the DAG run on
Airflow, identifying URL actually GETs the DAG run.

For note we get:
```
[2023-04-24, 14:19:27 UTC] {commit_operator.py:106} WARNING - metadata note not added: $Parent instance <DagRun at 0x7faebfedb2d0> is not bound to a Session; lazy load operation of attribute 'dag_run_note' cannot proceed (Background on this error at: https://sqlalche.me/e/14/bhk3) (possibly undefined fields)
```

Will open an issue to add that; there might be an issue with Airflow not
having a note at that point, or even a bug.

Needs treeverse/lakeFS#5765 actually to _display a button_ with the link to the DAG on Airflow.

Fixes #47.