### PR TITLE
Bump version to 0.46.1 to re-release with extra links feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG.md
 
+## 0.46.1
+
+  * Actually add those missing Airflow "extra links" (#67), missing in
+    0.46.0 :flushed:.  Without this you get buttons on lakeFS that take you
+    to Airflow, but no "extra links" (buttons) on Airflow that take you to
+    lakeFS.
+
 ## 0.46.0
 
   * Add Airflow DAG metadata to lakeFS commits and to merges (#47, #56, #57).

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.md", "r") as fh:
 """Perform the package airflow-provider-lakeFS setup."""
 setup(
     name='airflow-provider-lakefs',
-    version='0.46.0',
+    version='0.46.1',
     description='A lakeFS provider package built by Treeverse.',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
This is a **patch release**: I mistakenly released without extra links but
CHANGELOG says it's there.  So it's a bugfix (patch), not a feature (minor).