### PR TITLE
feat: add branch delete operator

### DIFF
--- a/lakefs_provider/hooks/lakefs_hook.py
+++ b/lakefs_provider/hooks/lakefs_hook.py
@@ -155,6 +155,10 @@ class LakeFSHook(BaseHook):
 
         return client.metadata.create_symlink_file(repository=repo, branch=branch, **kwargs)["location"]
 
+    def delete_branch(self, repo: str, branch: str) -> str:
+        client = self.get_conn()
+        return client.branches.delete_branch(repository=repo, branch=branch)
+
     def test_connection(self):
         """Test  Connection"""
         conn = self.get_connection(self.lakefs_conn_id)

--- a/lakefs_provider/operators/delete_branch_operator.py
+++ b/lakefs_provider/operators/delete_branch_operator.py
@@ -1,0 +1,41 @@
+from typing import Any, Callable, Dict, Optional
+
+from airflow.exceptions import AirflowException
+from airflow.models import BaseOperator
+from airflow.utils.decorators import apply_defaults
+
+from lakefs_provider.hooks.lakefs_hook import LakeFSHook
+
+
+class LakeFSDeleteBranchOperator(BaseOperator):
+    """
+    Delete a lakeFS branch by calling the lakeFS server.
+
+    :param lakefs_conn_id: connection to run the operator with
+    :type lakefs_conn_id: str
+    :param repo: The lakeFS repo where the branch is deleted.
+    :type repo: str
+    :param branch: The branch name to delete
+    :type branch: str
+    """
+
+    # Specify the arguments that are allowed to parse with jinja templating
+    template_fields = [
+        'repo',
+        'branch',
+    ]
+    template_ext = ()
+    ui_color = '#f4a460'
+
+    @apply_defaults
+    def __init__(self, lakefs_conn_id: str, repo: str, branch: str, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.lakefs_conn_id = lakefs_conn_id
+        self.repo = repo
+        self.branch = branch
+
+    def execute(self, context: Dict[str, Any]) -> Any:
+        hook = LakeFSHook(lakefs_conn_id=self.lakefs_conn_id)
+
+        self.log.info(f"Delete lakeFS branch {self.branch} in repo {self.repo}")
+        return hook.delete_branch(self.repo, self.branch)


### PR DESCRIPTION
Closes #53

Add new Airflow Operator `LakeFSDeleteBranchOperator` to delete branches by calling the LakeFS server.

Example:
1. Create a new branch on a LakeFS repo, e.g.: branch named `delete_me` on repo named `example`
2. Add the following to your Airflow DAG:
   ```python
   # new import
   from lakefs_provider.operators.delete_branch_operator import LakeFSDeleteBranchOperator

   # define delete branch task
   task_delete_branch = LakeFSDeleteBranchOperator(
        task_id="delete_branch",
        repo="example",
        branch="delete_me")
   ```
3. Run the DAG and check that the branch is now gone from the `example` repo