### PR TITLE
Bump version to 0.46.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.md", "r") as fh:
 """Perform the package airflow-provider-lakeFS setup."""
 setup(
     name='airflow-provider-lakefs',
-    version='0.46.2',
+    version='0.46.3',
     description='A lakeFS provider package built by Treeverse.',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
This is a _patch_ release: arranges b/c with previous Airflow versions, which is either a bugfix or a change that adds no new interfaces.