### PR TITLE
Add client ID to lakeFS client connections

### DIFF
--- a/lakefs_provider/__init__.py
+++ b/lakefs_provider/__init__.py
@@ -1,3 +1,5 @@
+__version__ = '0.46.3'
+
 ## This is needed to allow Airflow to pick up specific metadata fields it needs for certain features. We recognize it's a bit unclean to define these in multiple places, but at this point it's the only workaround if you'd like your custom conn type to show up in the Airflow UI.
 def get_provider_info():
     return {

--- a/lakefs_provider/hooks/lakefs_hook.py
+++ b/lakefs_provider/hooks/lakefs_hook.py
@@ -33,7 +33,7 @@ class LakeFSHook(BaseHook):
     :type lakefs_conn_id: str
     """
     conn_name_attr = "lakefs_conn_id"
-    client_id = f"lakefs-airflow-provider ({__version__ if __version__ else 'dev'})"
+    client_id = f"lakefs-airflow-provider/{__version__ if __version__ else 'dev'}"
     default_conn_name = "lakefs_default"
     conn_type = "lakefs"
     hook_name = "lakeFS"

--- a/lakefs_provider/hooks/lakefs_hook.py
+++ b/lakefs_provider/hooks/lakefs_hook.py
@@ -1,5 +1,7 @@
 from typing import Any, Dict, IO, Iterator
 
+from lakefs_provider.version import __version__
+
 import lakefs_client
 from lakefs_client import models
 from lakefs_client.client import LakeFSClient
@@ -31,6 +33,7 @@ class LakeFSHook(BaseHook):
     :type lakefs_conn_id: str
     """
     conn_name_attr = "lakefs_conn_id"
+    client_id = f"lakefs-airflow-provider ({__version__ if __version__ else 'dev'})"
     default_conn_name = "lakefs_default"
     conn_type = "lakefs"
     hook_name = "lakeFS"
@@ -62,7 +65,8 @@ class LakeFSHook(BaseHook):
         if not configuration.host:
             raise AirflowException("lakeFS endpoint must be specified in the lakeFS connection details")
 
-        return LakeFSClient(configuration)
+        return LakeFSClient(configuration,
+                            header_name='X-Lakefs-Client', header_value=self.client_id)
 
     @staticmethod
     def get_ui_field_behaviour():

--- a/lakefs_provider/hooks/lakefs_hook.py
+++ b/lakefs_provider/hooks/lakefs_hook.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, IO, Iterator
 
-from lakefs_provider.version import __version__
+from lakefs_provider import __version__
 
 import lakefs_client
 from lakefs_client import models

--- a/lakefs_provider/hooks/lakefs_hook.py
+++ b/lakefs_provider/hooks/lakefs_hook.py
@@ -33,7 +33,7 @@ class LakeFSHook(BaseHook):
     :type lakefs_conn_id: str
     """
     conn_name_attr = "lakefs_conn_id"
-    client_id = f"lakefs-airflow-provider/{__version__ if __version__ else 'dev'}"
+    client_id = f"lakefs-airflow-provider/{__version__}"
     default_conn_name = "lakefs_default"
     conn_type = "lakefs"
     hook_name = "lakeFS"

--- a/lakefs_provider/version.py
+++ b/lakefs_provider/version.py
@@ -7,5 +7,17 @@ if sys.version_info >= (3, 8):
 else:
     import importlib_metadata as metadata
 
+
+def __get_version(package: str) -> str:
+    try:
+        return metadata.version(package)
+    except metadata.PackageNotFoundError as e:
+        print("No package metadata found")
+        return None
+    except Exception as e:
+        print(f"Get version: {e}")
+        return None
+
+
 # Extract version using method #5 of https://packaging.python.org/en/latest/guides/single-sourcing-package-version/#single-sourcing-the-version
-__version__ = metadata.version('airflow-provider-lakefs')
+__version__ = __get_version('airflow-provider-lakefs')

--- a/lakefs_provider/version.py
+++ b/lakefs_provider/version.py
@@ -1,0 +1,11 @@
+"""Report package version"""
+
+import sys
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
+
+# Extract version using method #5 of https://packaging.python.org/en/latest/guides/single-sourcing-package-version/#single-sourcing-the-version
+__version__ = metadata.version('airflow-provider-lakefs')

--- a/lakefs_provider/version.py
+++ b/lakefs_provider/version.py
@@ -2,22 +2,4 @@
 
 import sys
 
-if sys.version_info >= (3, 8):
-    from importlib import metadata
-else:
-    import importlib_metadata as metadata
-
-
-def __get_version(package: str) -> str:
-    try:
-        return metadata.version(package)
-    except metadata.PackageNotFoundError as e:
-        print("No package metadata found")
-        return None
-    except Exception as e:
-        print(f"Get version: {e}")
-        return None
-
-
-# Extract version using method #5 of https://packaging.python.org/en/latest/guides/single-sourcing-package-version/#single-sourcing-the-version
-__version__ = __get_version('airflow-provider-lakefs')
+__version__ = '0.46.3'

--- a/lakefs_provider/version.py
+++ b/lakefs_provider/version.py
@@ -1,5 +1,0 @@
-"""Report package version"""
-
-import sys
-
-__version__ = '0.46.3'

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 """Setup.py for the lakeFS Airflow provider package"""
 
 from setuptools import find_packages, setup
+from lakefs_provider.version import __version__
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
@@ -8,7 +9,7 @@ with open("README.md", "r") as fh:
 """Perform the package airflow-provider-lakeFS setup."""
 setup(
     name='airflow-provider-lakefs',
-    version='0.46.3',
+    version=__version__,
     description='A lakeFS provider package built by Treeverse.',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,6 @@
 """Setup.py for the lakeFS Airflow provider package"""
 
 from setuptools import find_packages, setup
-from lakefs_provider import __version__
-
 import re
 
 with open("README.md", "r") as fh:

--- a/setup.py
+++ b/setup.py
@@ -3,13 +3,26 @@
 from setuptools import find_packages, setup
 from lakefs_provider import __version__
 
+import re
+
 with open("README.md", "r") as fh:
     long_description = fh.read()
+
+def _get_version(fh):
+    r = re.compile("__version__ *= *[\"'](.*)[\"'] *")
+    for l in fh.readlines():
+        m = r.match(l)
+        if m:
+            return m.group(1)
+    raise RuntimeError(f"No lines in {fh.name} define __version__")
+
+with open("lakefs_provider/__init__.py", "r") as fh:
+    version = _get_version(fh)
 
 """Perform the package airflow-provider-lakeFS setup."""
 setup(
     name='airflow-provider-lakefs',
-    version=__version__,
+    version=version,
     description='A lakeFS provider package built by Treeverse.',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 """Setup.py for the lakeFS Airflow provider package"""
 
 from setuptools import find_packages, setup
-from lakefs_provider.version import __version__
+from lakefs_provider import __version__
 
 with open("README.md", "r") as fh:
     long_description = fh.read()


### PR DESCRIPTION
Format: "lakefs-airflow-provider (VERSION)".

Fixes #68.
