### PR TITLE
Release 0.47.0

### DIFF
--- a/lakefs_provider/__init__.py
+++ b/lakefs_provider/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.46.3'
+__version__ = '0.47.0'
 
 ## This is needed to allow Airflow to pick up specific metadata fields it needs for certain features. We recognize it's a bit unclean to define these in multiple places, but at this point it's the only workaround if you'd like your custom conn type to show up in the Airflow UI.
 def get_provider_info():


### PR DESCRIPTION
Minor bump justified because it changes the "downwards" API to include a
client ID.  This allows lakeFS admins to differentiate Airflow provider
actions from others -- a feature.