### PR TITLE
Use new lakefs python SDK

### DIFF
--- a/.github/workflows/provider.yaml
+++ b/.github/workflows/provider.yaml
@@ -50,7 +50,7 @@ jobs:
           python3 -m build
 
       - name: Install astro
-        run: curl -sSL https://install.astronomer.io | sudo bash -s -- 0.28.1
+        run: curl -sSL https://install.astronomer.io | sudo bash -s -- v1.19.3
 
       - name: Create astro dev env
         run: mkdir astro && cd astro && astro dev init

--- a/.github/workflows/provider.yaml
+++ b/.github/workflows/provider.yaml
@@ -50,9 +50,7 @@ jobs:
           python3 -m build
 
       - name: Install astro
-        env:
-          TAG: 0.28.1
-        run: curl -sSL https://install.astronomer.io | sudo bash -s
+        run: curl -sSL https://install.astronomer.io | sudo bash -s -- 0.28.1
 
       - name: Create astro dev env
         run: mkdir astro && cd astro && astro dev init

--- a/.github/workflows/provider.yaml
+++ b/.github/workflows/provider.yaml
@@ -50,7 +50,7 @@ jobs:
           python3 -m build
 
       - name: Install Astro CLI
-        run: curl -sSL https://install.astronomer.io | sudo bash -s -- v1.19.3
+        run: curl -sSL https://install.astronomer.io | sudo bash -s -- v1.19.2
 
       - name: Create astro dev env
         run: |

--- a/.github/workflows/provider.yaml
+++ b/.github/workflows/provider.yaml
@@ -49,11 +49,14 @@ jobs:
           python3 -m pip install build
           python3 -m build
 
-      - name: Install astro
+      - name: Install Astro CLI
         run: curl -sSL https://install.astronomer.io | sudo bash -s -- v1.19.3
 
       - name: Create astro dev env
-        run: mkdir astro && cd astro && astro dev init
+        run: |
+          mkdir astro
+          cd astro
+          astro dev init
 
       - name: Copy files
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.48.0
 
   * Use new lakeFS Python SDK v0.113.0
+    Adopt calls and response from lakeFS to new API
 
 ## 0.46.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG.md
 
+## 0.48.0
+
+  * Use new lakeFS Python SDK v0.113.0
+
 ## 0.46.2
 
   * Update lakeFS client SDK to v0.101.0.

--- a/dag_status.py
+++ b/dag_status.py
@@ -19,18 +19,19 @@ def get_latest_state():
 
 
 def dag_state():
-    state = get_latest_state()
-    timeout = time.time() + 60 * 5  # 5 minutes from now
-    while state != 'success' and state != 'failed' and state != 'skipped':
-        time.sleep(5)
-        if time.time() > timeout:
-            return 1
+    timeout = time.time() + 60 * 5  # five minutes from now
+    interval = 5 # five seconds
+    while True:
         state = get_latest_state()
-        continue
-    if state == 'success':
-        return 0
-    else:
+        if state == 'success' or state == 'failed' or state == 'skipped':
+            break
+        if time.time()+interval > timeout:
+            break
+        time.sleep(interval)
+    print("dag_state", state)
+    if state != 'success':
         return 1
+    return 0
 
 
 sys.exit(dag_state())

--- a/dag_status.py
+++ b/dag_status.py
@@ -11,7 +11,9 @@ def get_latest_state():
     username = 'admin'
     password = 'admin'
     response = requests.get(url, auth=(username, password))
-    latest = max(response.json()['dag_runs'], key=lambda k: k['execution_date'])
+    response.raise_for_status()
+    dag_runs = response.json()['dag_runs']
+    latest = max(dag_runs, key=lambda k: k['execution_date'])
     state = latest['state']
     return state
 

--- a/lakefs_provider/__init__.py
+++ b/lakefs_provider/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.47.0'
+__version__ = '0.48.0'
 
 ## This is needed to allow Airflow to pick up specific metadata fields it needs for certain features. We recognize it's a bit unclean to define these in multiple places, but at this point it's the only workaround if you'd like your custom conn type to show up in the Airflow UI.
 def get_provider_info():

--- a/lakefs_provider/example_dags/lakefs-dag.py
+++ b/lakefs_provider/example_dags/lakefs-dag.py
@@ -10,7 +10,7 @@ from airflow.decorators import dag
 from airflow.utils.dates import days_ago
 from airflow.exceptions import AirflowFailException
 
-from lakefs_client.exceptions import NotFoundException
+from lakefs_sdk.exceptions import NotFoundException
 from lakefs_provider.hooks.lakefs_hook import LakeFSHook
 from lakefs_provider.operators.create_branch_operator import LakeFSCreateBranchOperator
 from lakefs_provider.operators.create_symlink_operator import LakeFSCreateSymlinkOperator

--- a/lakefs_provider/hooks/lakefs_hook.py
+++ b/lakefs_provider/hooks/lakefs_hook.py
@@ -5,7 +5,7 @@ from lakefs_provider import __version__
 import lakefs_sdk
 from lakefs_sdk import models
 from lakefs_sdk.client import LakeFSClient
-from lakefs_sdk.model.object_stats import ObjectStats
+from lakefs_sdk.models.object_stats import ObjectStats
 from lakefs_sdk.models import Merge
 
 from airflow.exceptions import AirflowException

--- a/lakefs_provider/hooks/lakefs_hook.py
+++ b/lakefs_provider/hooks/lakefs_hook.py
@@ -100,7 +100,7 @@ class LakeFSHook(BaseHook):
             repository=repo,
             branch=branch,
             path=path,
-            content=content)
+            content=content.read())
 
         return upload.physical_address
 

--- a/lakefs_provider/hooks/lakefs_hook.py
+++ b/lakefs_provider/hooks/lakefs_hook.py
@@ -2,11 +2,11 @@ from typing import Any, Dict, IO, Iterator
 
 from lakefs_provider import __version__
 
-import lakefs_client
-from lakefs_client import models
-from lakefs_client.client import LakeFSClient
-from lakefs_client.model.object_stats import ObjectStats
-from lakefs_client.models import Merge
+import lakefs_sdk
+from lakefs_sdk import models
+from lakefs_sdk.client import LakeFSClient
+from lakefs_sdk.model.object_stats import ObjectStats
+from lakefs_sdk.models import Merge
 
 from airflow.exceptions import AirflowException
 from airflow.hooks.base import BaseHook
@@ -50,7 +50,7 @@ class LakeFSHook(BaseHook):
 
     def get_conn(self) -> LakeFSClient:
         conn = self.get_connection(self.lakefs_conn_id)
-        configuration = lakefs_client.Configuration()
+        configuration = lakefs_sdk.Configuration()
         if conn.conn_type == "http" and conn.extra_dejson.get("access_key_id") and conn.extra_dejson.get("secret_access_key"):
             configuration.username = conn.extra_dejson.get("access_key_id")
             configuration.password = conn.extra_dejson.get("secret_access_key")

--- a/lakefs_provider/hooks/lakefs_hook.py
+++ b/lakefs_provider/hooks/lakefs_hook.py
@@ -12,18 +12,6 @@ from airflow.exceptions import AirflowException
 from airflow.hooks.base import BaseHook
 
 
-def _commitAsDict(details):
-    return {
-        "id": details.id,
-        "parents": details.parents,
-        "committer": details.committer,
-        "message": details.message,
-        "creation_date": details.creation_date,
-        "meta_range_id": details.meta_range_id,
-        "metadata": details.metadata,
-    }
-
-
 class LakeFSHook(BaseHook):
     """
     LakeFSHook that interacts with a lakeFS server.
@@ -51,7 +39,8 @@ class LakeFSHook(BaseHook):
     def get_conn(self) -> LakeFSClient:
         conn = self.get_connection(self.lakefs_conn_id)
         configuration = lakefs_sdk.Configuration()
-        if conn.conn_type == "http" and conn.extra_dejson.get("access_key_id") and conn.extra_dejson.get("secret_access_key"):
+        if conn.conn_type == "http" and conn.extra_dejson.get("access_key_id") and conn.extra_dejson.get(
+                "secret_access_key"):
             configuration.username = conn.extra_dejson.get("access_key_id")
             configuration.password = conn.extra_dejson.get("secret_access_key")
         else:
@@ -82,7 +71,6 @@ class LakeFSHook(BaseHook):
         ref = client.branches_api.create_branch(
             repository=repository, branch_creation=models.BranchCreation(name=name,
                                                                          source=source_branch))
-
         return ref
 
     def commit(self, repo: str, branch: str, msg: str, metadata: Dict[str, Any] = None) -> str:
@@ -92,15 +80,15 @@ class LakeFSHook(BaseHook):
             branch=branch,
             commit_creation=models.CommitCreation(message=msg, metadata=metadata))
 
-        return commit.get("id")
+        return commit.id
 
-    def upload(self, repo: str, branch: str, path: str, content: IO) -> str:
+    def upload(self, repo: str, branch: str, path: str, content: bytes) -> str:
         client = self.get_conn()
         upload = client.objects_api.upload_object(
             repository=repo,
             branch=branch,
             path=path,
-            content=content.read())
+            content=content)
 
         return upload.physical_address
 
@@ -113,7 +101,7 @@ class LakeFSHook(BaseHook):
             destination_branch=destination_branch,
             merge=Merge(message=msg, metadata=metadata))
 
-        return merge_result.get("reference")
+        return merge_result.reference
 
     def get_branch_commit_id(self, repo: str, name: str) -> str:
         client = self.get_conn()
@@ -122,54 +110,53 @@ class LakeFSHook(BaseHook):
 
     def get_commit(self, repo: str, ref: str) -> Dict[str, str]:
         client = self.get_conn()
-        # Actually ask for a log of length 1, because of treeverse/lakeFS#3436.
-        response = client.refs_api.log_commits(repo, ref, amount=1)
-        details = response.results[0]
-        return _commitAsDict(details)
+        commit = client.commits_api.get_commit(repo, ref)
+        return commit.to_dict()
 
-    def log_commits(self, repo: str, ref: str, size: int=100) -> Iterator:
+    def log_commits(self, repo: str, ref: str, size: int = 100) -> Iterator:
         """Yield commits of repo backwards from ref.
-
         Fetch size commits at a time."""
         client = self.get_conn()
-        log_commits = client.refs_api.log_commits
         after = ''
         while True:
-            response = log_commits(repo, ref, amount=size, after=after)
+            response = client.refs_api.log_commits(repo, ref, amount=size, after=after)
             for details in response.results:
-                yield _commitAsDict(details)
+                yield details.to_dict()
             if response.pagination is None or not response.pagination.has_more:
                 return
             after = response.pagination.next_offset
 
     def stat_object(self, repo: str, ref: str, path: str) -> ObjectStats:
         client = self.get_conn()
-        return client.objects_api.stat_object(repository=repo, ref=ref, path=path)
+        response = client.objects_api.stat_object(repository=repo, ref=ref, path=path)
+        return response.to_dict()
 
     def get_object(self, repo: str, ref: str, path: str) -> IO:
         client = self.get_conn()
         return client.objects_api.get_object(repository=repo, ref=ref, path=path)
 
-    def create_symlink_file(self, repo: str, branch: str, location: str = None)  -> str:
+    def create_symlink_file(self, repo: str, branch: str, location: str = None) -> str:
         client = self.get_conn()
 
         kwargs = {}
         if location:
             kwargs["location"] = location
 
-        return client.internal_api.create_symlink_file(repository=repo, branch=branch, **kwargs)["location"]
+        response = client.internal_api.create_symlink_file(repository=repo, branch=branch, **kwargs)
+        return response.location
 
     def delete_branch(self, repo: str, branch: str) -> str:
         client = self.get_conn()
         return client.branches_api.delete_branch(repository=repo, branch=branch)
 
     def test_connection(self):
-        """Test  Connection"""
+        """Test Connection"""
         conn = self.get_connection(self.lakefs_conn_id)
         import requests
         import json
-        url = conn.host+"/api/v1/auth/login"
-        if conn.conn_type == "http" and conn.extra_dejson.get("access_key_id") and conn.extra_dejson.get("secret_access_key"):
+        url = conn.host + "/api/v1/auth/login"
+        if conn.conn_type == "http" and conn.extra_dejson.get("access_key_id") and conn.extra_dejson.get(
+                "secret_access_key"):
             login = conn.extra_dejson.get("access_key_id")
             password = conn.extra_dejson.get("secret_access_key")
         else:
@@ -183,10 +170,10 @@ class LakeFSHook(BaseHook):
         response = requests.request("POST", url, headers=headers, data=payload)
         try:
             response.raise_for_status()
-            return True,"Connection Tested Successfully"
+            return True, "Connection Tested Successfully"
         except requests.exceptions.URLRequired as e:
-            return  False,str(e)
+            return False, str(e)
         except requests.exceptions.HTTPError as e:
-            return  False,str(e)
+            return False, str(e)
         except requests.exceptions.RequestException as e:
-            return  False,str(e)
+            return False, str(e)

--- a/lakefs_provider/operators/get_object_operator.py
+++ b/lakefs_provider/operators/get_object_operator.py
@@ -45,5 +45,4 @@ class LakeFSGetObjectOperator(BaseOperator):
                       self.repo, self.ref, self.path)
 
         contents = hook.get_object(self.repo, self.ref, self.path)
-
-        return str(contents.read(), 'utf-8')
+        return str(contents, 'utf-8')

--- a/lakefs_provider/operators/upload_operator.py
+++ b/lakefs_provider/operators/upload_operator.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, IO
+from typing import Any, Dict
 
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
@@ -19,7 +19,7 @@ class LakeFSUploadOperator(BaseOperator):
     :param path: The path for the desired object.
     :type msg: str
     :param content: Contents of the desired object.
-    :type content: typing.IO
+    :type content: bytes
     """
 
     # Specify the arguments that are allowed to parse with jinja templating
@@ -32,7 +32,7 @@ class LakeFSUploadOperator(BaseOperator):
     ui_color = '#f4a460'
 
     @apply_defaults
-    def __init__(self, lakefs_conn_id: str, repo: str, branch: str, path: str, content: IO = None, **kwargs: Any) -> None:
+    def __init__(self, lakefs_conn_id: str, repo: str, branch: str, path: str, content: bytes, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.lakefs_conn_id = lakefs_conn_id
         self.repo = repo
@@ -43,7 +43,7 @@ class LakeFSUploadOperator(BaseOperator):
     def execute(self, context: Dict[str, Any]) -> Any:
         hook = LakeFSHook(lakefs_conn_id=self.lakefs_conn_id)
 
-        self.log.info("Uploading to path '%s' on lakeFS branch '%s' in repo '%s'",
-                      self.path, self.branch, self.repo)
+        self.log.info("Uploading to path '%s' on lakeFS branch '%s' in repo '%s' (content type: %s)",
+                      self.path, self.branch, self.repo, type(self.content))
 
         return hook.upload(self.repo, self.branch, self.path, self.content)

--- a/lakefs_provider/sensors/commit_sensor.py
+++ b/lakefs_provider/sensors/commit_sensor.py
@@ -2,7 +2,7 @@ from typing import Any, Dict
 
 from airflow.sensors.base import BaseSensorOperator
 from airflow.utils.decorators import apply_defaults
-from lakefs_client.exceptions import NotFoundException
+from lakefs_sdk.exceptions import NotFoundException
 
 from lakefs_provider.hooks.lakefs_hook import LakeFSHook
 

--- a/lakefs_provider/sensors/file_sensor.py
+++ b/lakefs_provider/sensors/file_sensor.py
@@ -2,7 +2,7 @@ from typing import Any, Dict
 
 from airflow.sensors.base import BaseSensorOperator
 from airflow.utils.decorators import apply_defaults
-from lakefs_client.exceptions import NotFoundException
+from lakefs_sdk.exceptions import NotFoundException
 
 from lakefs_provider.hooks.lakefs_hook import LakeFSHook
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-lakefs_client~=0.112.1
+lakefs_client~=0.113.0
 setuptools~=56.0.0
 requests~=2.31.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-lakefs_sdk~=0.113.0
+lakefs_sdk>=0.113.0
 setuptools~=56.0.0
 requests~=2.31.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-lakefs_client~=0.113.0
+lakefs_sdk~=0.113.0
 setuptools~=56.0.0
 requests~=2.31.0

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     packages=['lakefs_provider', 'lakefs_provider.hooks', 'lakefs_provider.links',
               'lakefs_provider.sensors', 'lakefs_provider.operators',
               'lakefs_provider.example_dags'],
-    install_requires=['apache-airflow>=2.0', 'lakefs_sdk~=0.113.0'],
+    install_requires=['apache-airflow>=2.0', 'lakefs_sdk>=0.113.0.2'],
     setup_requires=['setuptools', 'wheel'],
     author='Treeverse',
     author_email='services@treeverse.io',

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     packages=['lakefs_provider', 'lakefs_provider.hooks', 'lakefs_provider.links',
               'lakefs_provider.sensors', 'lakefs_provider.operators',
               'lakefs_provider.example_dags'],
-    install_requires=['apache-airflow>=2.0', 'lakefs_client>=0.112.1'],
+    install_requires=['apache-airflow>=2.0', 'lakefs_client>=0.113.0'],
     setup_requires=['setuptools', 'wheel'],
     author='Treeverse',
     author_email='services@treeverse.io',

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     packages=['lakefs_provider', 'lakefs_provider.hooks', 'lakefs_provider.links',
               'lakefs_provider.sensors', 'lakefs_provider.operators',
               'lakefs_provider.example_dags'],
-    install_requires=['apache-airflow>=2.0', 'lakefs_client>=0.113.0'],
+    install_requires=['apache-airflow>=2.0', 'lakefs_sdk~=0.113.0'],
     setup_requires=['setuptools', 'wheel'],
     author='Treeverse',
     author_email='services@treeverse.io',

--- a/setup.py
+++ b/setup.py
@@ -38,5 +38,5 @@ setup(
     author='Treeverse',
     author_email='services@treeverse.io',
     url='https://lakefs.io',
-    python_requires='>=3.6',
+    python_requires='>=3.7',
 )

--- a/tests/operators/test_create_symlink_operators.py
+++ b/tests/operators/test_create_symlink_operators.py
@@ -37,9 +37,9 @@ def test_create_symlink_file_with_location(mock_conn):
     # Mock client
     mock_client = Mock(LakeFSClient)()
     mock_conn.return_value = mock_client
-    mock_client.internal_api.create_symlink_file.return_value = {
-        "location": "file://custom/path/to/symlink"
-    }
+    mock_client.internal_api.create_symlink_file.return_value = StorageURI.from_dict({
+        "location": "file://custom/path/to/symlink",
+    })
 
     # Init Hook
     operator = LakeFSCreateSymlinkOperator(

--- a/tests/operators/test_create_symlink_operators.py
+++ b/tests/operators/test_create_symlink_operators.py
@@ -1,6 +1,6 @@
 from unittest.mock import Mock, patch
 
-from lakefs_client.client import LakeFSClient
+from lakefs_sdk.client import LakeFSClient
 
 from lakefs_provider.hooks.lakefs_hook import LakeFSHook
 from lakefs_provider.operators.create_symlink_operator import (

--- a/tests/operators/test_create_symlink_operators.py
+++ b/tests/operators/test_create_symlink_operators.py
@@ -1,5 +1,6 @@
 from unittest.mock import Mock, patch
 
+from lakefs_sdk.models.storage_uri import StorageURI
 from lakefs_sdk.client import LakeFSClient
 
 from lakefs_provider.hooks.lakefs_hook import LakeFSHook
@@ -13,9 +14,11 @@ def test_create_symlink_file(mock_conn):
     # Mock client
     mock_client = Mock(LakeFSClient)()
     mock_conn.return_value = mock_client
-    mock_client.internal_api.create_symlink_file.return_value = {
-        "location": "file://path/to/symlink"
-    }
+
+    # Mock response
+    mock_client.internal_api.create_symlink_file.return_value = StorageURI.from_dict({
+        "location": "file://path/to/symlink",
+    })
 
     # Init Hook
     operator = LakeFSCreateSymlinkOperator(


### PR DESCRIPTION
Update code to use the new lakeFS Python SDK:

- Update package version to 0.48.0
- upload object: switch to use bytes instead of IO to pass content
- Astro CLI: lock on v1.19.2 (latest failed with bug in astro cli trying to add connection)
- Use new SDK to_dict when possible instead of our own convert
- Fix get_commit workaround using commit log

Close https://github.com/treeverse/airflow-provider-lakeFS/issues/80